### PR TITLE
fix(routing): avoid /EN/404.html rewrite loop

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -131,6 +131,9 @@
 /EN/projects/portfolio.html    /projects/portfolio    301
 # END GENERATED (fix-seo)
 # 404 Fallback (Pages does not support 404 rewrites; use 200 proxy)
-/404.html                    /EN/404.html                301
-/EN/404                      /EN/404.html                200
-/*                           /EN/404.html                200
+# Use the clean URL (/EN/404) as the canonical 404 target.
+# Cloudflare Pages may redirect *.html -> clean URL (308), which can loop
+# if we rewrite /EN/404 back to /EN/404.html.
+/404.html                    /EN/404                     301
+/EN/404.html                 /EN/404                     301
+/*                           /EN/404                     200

--- a/tools/fix-seo.mjs
+++ b/tools/fix-seo.mjs
@@ -161,9 +161,12 @@ function generateRedirects() {
     const footerLines = [
         '',
         '# 404 Fallback (Pages does not support 404 rewrites; use 200 proxy)',
-        '/404.html                    /EN/404.html                301',
-        '/EN/404                      /EN/404.html                200',
-        '/*                           /EN/404.html                200',
+        '# Use the clean URL (/EN/404) as the canonical 404 target.',
+        '# Cloudflare Pages may redirect *.html -> clean URL (308), which can loop',
+        '# if we rewrite /EN/404 back to /EN/404.html.',
+        '/404.html                    /EN/404                     301',
+        '/EN/404.html                 /EN/404                     301',
+        '/*                           /EN/404                     200',
         '',
     ];
 


### PR DESCRIPTION
Fixes Cloudflare Pages clean-URL redirect loop triggered by rewriting /EN/404 -> /EN/404.html. Switch fallback to canonical /EN/404.