### PR TITLE
chore(guardrails): sw cache bump + secrets audit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,12 @@ jobs:
 
       - run: npm ci
 
+      - name: "Guardrails: SW cache bump"
+        run: npm run audit:sw-cache
+
+      - name: "Guardrails: Secrets scan"
+        run: npm run audit:secrets
+
       - run: npm run check:csp
 
       - run: npx playwright install --with-deps chromium

--- a/.github/workflows/quality-gates.yml
+++ b/.github/workflows/quality-gates.yml
@@ -33,6 +33,12 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: "Guardrails: SW cache bump"
+        run: npm run audit:sw-cache
+
+      - name: "Guardrails: Secrets scan"
+        run: npm run audit:secrets
+
       - name: Build JS
         run: npm run build:js
 
@@ -87,6 +93,12 @@ jobs:
           echo "PUPPETEER_EXECUTABLE_PATH=${{ steps.setup-chrome.outputs.chrome-path }}" >> $GITHUB_ENV
       - name: Install dependencies
         run: npm ci
+
+      - name: "Guardrails: SW cache bump"
+        run: npm run audit:sw-cache
+
+      - name: "Guardrails: Secrets scan"
+        run: npm run audit:secrets
       - name: Build JS
         run: npm run build:js
       - name: Route Smoke Test

--- a/.github/workflows/verify-pages.yml
+++ b/.github/workflows/verify-pages.yml
@@ -16,4 +16,11 @@ jobs:
           node-version: 20
           cache: npm
       - run: npm ci
+
+      - name: "Guardrails: SW cache bump"
+        run: npm run audit:sw-cache
+
+      - name: "Guardrails: Secrets scan"
+        run: npm run audit:secrets
+
       - run: npm run verify:pages

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
         "audit:redirects-assets": "node tools/audit-redirects-assets.mjs",
         "audit:html-sanity": "node tools/audit-html-sanity.cjs",
         "audit:secrets": "node tools/audit-secrets.mjs",
+        "audit:sw-cache": "node tools/audit-sw-cache.mjs",
         "audit": "npm run audit:secrets && npm run audit:cf-files && npm run audit:inline-css && npm run audit:css-sync && npm run audit:redirects-assets && npm run audit:html-sanity",
         "audit:links": "powershell -NoProfile -ExecutionPolicy Bypass -File tools/link-check.ps1",
         "audit:links:node": "node tools/link-check.mjs --inventory .reports/_latest --outDir .reports/_latest",

--- a/sw.js
+++ b/sw.js
@@ -7,7 +7,7 @@
 //
 // Cache Version: Bump this whenever you deploy changes that affect cached files
 // ==========================================================================
-const CACHE_VERSION = 'v1769316949006';
+const CACHE_VERSION = 'v1769316949007';
 const CACHE_NAME = `portfolio-${CACHE_VERSION}`;
 const ASSETS_TO_CACHE = [
     '/',

--- a/tools/audit-secrets.mjs
+++ b/tools/audit-secrets.mjs
@@ -1,52 +1,41 @@
 import fs from 'node:fs';
 import path from 'node:path';
+import { execFileSync } from 'node:child_process';
 
 const ROOT = process.cwd();
 
+// Determinism + noise control:
+// - Scan tracked files only (git ls-files)
+// - Ignore common noise dirs even if they appear in a path
 const IGNORE_DIRS = new Set(['.git', '.reports', 'node_modules', 'lighthouse-results']);
 
-const SCAN_TARGETS = [
-  'EN',
-  'es',
-  'ar',
-  'assets',
-  'worker',
-  'sw.js',
-  'theme.css',
-  '_headers',
-  '_redirects',
-  'package.json',
-];
-
-/** @type {Array<{name: string, re: RegExp}>} */
+/** @type {Array<{name: string, re: RegExp, severity: 'fail' | 'warn'}>} */
 const PATTERNS = [
-  { name: 'Google API key', re: /AIza[0-9A-Za-z-_]{20,}/g },
-  { name: 'Private key PEM', re: /-----BEGIN (?:RSA |EC |OPENSSH )?PRIVATE KEY-----/g },
-  { name: 'Bearer token', re: /Bearer\s+\S{20,}/g },
+  // High-signal "this might be a real secret" patterns (fail CI)
+  { name: 'Google API key (AIza...)', re: /AIza[0-9A-Za-z-_]{20,}/g, severity: 'fail' },
+  { name: 'GitHub token (gho_)', re: /gho_[0-9A-Za-z]{10,}/g, severity: 'fail' },
+  { name: 'Private key PEM', re: /-----BEGIN (?:RSA |EC |OPENSSH )?PRIVATE KEY-----/g, severity: 'fail' },
+  { name: 'Bearer token (long)', re: /Bearer\s+\S{20,}/g, severity: 'fail' },
+
+  // Required scan patterns (informational by default; commonly appear in docs/config)
+  { name: 'GEMINI_API_KEY (any case)', re: /gemini_api_key/gi, severity: 'warn' },
+  { name: 'x-goog-api-key header', re: /x-goog-api-key/gi, severity: 'warn' },
+  { name: 'Gemini endpoint (generativelanguage.googleapis.com)', re: /generativelanguage\.googleapis\.com/gi, severity: 'warn' },
+  { name: 'Authorization: Bearer header', re: /authorization\s*:\s*bearer/gi, severity: 'warn' },
 ];
 
 function toRel(fullPath) {
   return path.relative(ROOT, fullPath).replace(/\\/g, '/');
 }
 
-function shouldIgnoreDirName(name) {
-  return IGNORE_DIRS.has(name);
-}
-
-function walkDir(dir) {
-  /** @type {string[]} */
-  const results = [];
-  const entries = fs.readdirSync(dir, { withFileTypes: true });
-  for (const entry of entries) {
-    if (entry.isDirectory() && shouldIgnoreDirName(entry.name)) continue;
-    const full = path.join(dir, entry.name);
-    if (entry.isDirectory()) {
-      results.push(...walkDir(full));
-      continue;
-    }
-    if (entry.isFile()) results.push(full);
-  }
-  return results;
+function listTrackedFiles() {
+  const out = execFileSync('git', ['ls-files', '-z'], { encoding: 'utf8' });
+  return out
+    .split('\0')
+    .map((s) => s.trim())
+    .filter(Boolean)
+    .map((p) => p.replace(/\\/g, '/'))
+    .sort();
 }
 
 function isBinaryByExt(relPath) {
@@ -95,10 +84,11 @@ function scanFile(fullPath) {
     const lineText = lines[i];
 
     for (const p of PATTERNS) {
+      p.re.lastIndex = 0;
       const matches = lineText.matchAll(p.re);
       for (const m of matches) {
         if (!m[0]) continue;
-        hits.push({ file: rel, line: i + 1, pattern: p.name, match: m[0] });
+        hits.push({ file: rel, line: i + 1, pattern: p.name, match: m[0], severity: p.severity });
       }
     }
   }
@@ -106,35 +96,75 @@ function scanFile(fullPath) {
   return hits;
 }
 
-function main() {
-  /** @type {string[]} */
-  const filesToScan = [];
-
-  for (const target of SCAN_TARGETS) {
-    const full = path.join(ROOT, target);
-    if (!fs.existsSync(full)) continue;
-    const stat = fs.statSync(full);
-    if (stat.isDirectory()) {
-      filesToScan.push(...walkDir(full));
-    } else if (stat.isFile()) {
-      filesToScan.push(full);
+function parseArgs(argv) {
+  /** @type {Record<string, string | boolean>} */
+  const args = {};
+  for (let i = 2; i < argv.length; i++) {
+    const a = argv[i];
+    if (!a.startsWith('--')) continue;
+    const key = a.slice(2);
+    const next = argv[i + 1];
+    if (!next || next.startsWith('--')) {
+      args[key] = true;
+      continue;
     }
+    args[key] = next;
+    i++;
   }
+  return args;
+}
 
-  /** @type {Array<{file: string, line: number, pattern: string, match: string}>} */
+function main() {
+  const args = parseArgs(process.argv);
+  const failOnWarn = args['fail-on-warn'] === true || args['fail-on-warn'] === 'true';
+  const tracked = listTrackedFiles();
+  const filesToScan = tracked
+    .filter((p) => {
+      const segments = p.split('/');
+      return !segments.some((s) => IGNORE_DIRS.has(s));
+    })
+    .map((p) => path.join(ROOT, p));
+
+  /** @type {Array<{file: string, line: number, pattern: string, match: string, severity: 'fail' | 'warn'}>} */
   const hits = [];
   for (const f of filesToScan) hits.push(...scanFile(f));
 
-  if (hits.length === 0) {
+  hits.sort((a, b) => {
+    if (a.file !== b.file) return a.file.localeCompare(b.file);
+    if (a.line !== b.line) return a.line - b.line;
+    if (a.pattern !== b.pattern) return a.pattern.localeCompare(b.pattern);
+    return a.match.localeCompare(b.match);
+  });
+
+  const failHits = hits.filter((h) => h.severity === 'fail');
+  const warnHits = hits.filter((h) => h.severity === 'warn');
+
+  if (failHits.length === 0 && warnHits.length === 0) {
     console.log('OK: no secret-like material found');
     process.exit(0);
   }
 
-  console.error('FAIL: secret-like material found');
-  for (const h of hits) {
-    console.error(`${h.file}:${h.line}: ${h.pattern}: ${h.match}`);
+  if (warnHits.length > 0) {
+    console.log('WARN: informational secret-adjacent strings found');
+    for (const h of warnHits) {
+      console.log(`${h.file}:${h.line}: ${h.pattern}: ${h.match}`);
+    }
   }
-  process.exit(1);
+
+  if (failHits.length > 0) {
+    console.error('FAIL: secret-like material found');
+    for (const h of failHits) {
+      console.error(`${h.file}:${h.line}: ${h.pattern}: ${h.match}`);
+    }
+    process.exit(1);
+  }
+
+  if (failOnWarn) {
+    console.error('FAIL: fail-on-warn enabled and informational matches were found');
+    process.exit(1);
+  }
+
+  process.exit(0);
 }
 
 main();

--- a/tools/audit-sw-cache.mjs
+++ b/tools/audit-sw-cache.mjs
@@ -1,0 +1,144 @@
+import fs from 'node:fs';
+import { execFileSync } from 'node:child_process';
+
+function parseArgs(argv) {
+  /** @type {Record<string, string | boolean>} */
+  const args = {};
+  for (let i = 2; i < argv.length; i++) {
+    const a = argv[i];
+    if (!a.startsWith('--')) continue;
+    const key = a.slice(2);
+    const next = argv[i + 1];
+    if (!next || next.startsWith('--')) {
+      args[key] = true;
+      continue;
+    }
+    args[key] = next;
+    i++;
+  }
+  return args;
+}
+
+function normalizePath(p) {
+  return (p || '').replace(/\\/g, '/').replace(/^\.\//, '');
+}
+
+function readSwFromRef(ref) {
+  return execFileSync('git', ['show', `${ref}:sw.js`], { encoding: 'utf8' });
+}
+
+function readSwFromWorktree() {
+  return fs.readFileSync('sw.js', 'utf8');
+}
+
+function extractCacheVersion(swText) {
+  const re = /const\s+CACHE_VERSION\s*=\s*['"]([^'"]+)['"]\s*;/;
+  const m = swText.match(re);
+  return m ? m[1] : null;
+}
+
+function listChangedFiles(baseRef) {
+  const out = execFileSync('git', ['diff', '--name-only', '-z', `${baseRef}...HEAD`], {
+    encoding: 'utf8',
+  });
+  return out
+    .split('\0')
+    .map((s) => s.trim())
+    .filter(Boolean)
+    .map(normalizePath);
+}
+
+function matchesTrigger(file) {
+  const f = normalizePath(file);
+
+  const exact = new Set([
+    'index.html',
+    '_redirects',
+    '_headers',
+    'assets/js/site.min.js',
+    'assets/js/lazy-loader.min.js',
+    'assets/css/style.css',
+    'sw.js',
+  ]);
+  if (exact.has(f)) return true;
+
+  const prefixes = ['EN/', 'ar/', 'es/'];
+  return prefixes.some((p) => f.startsWith(p));
+}
+
+function main() {
+  const args = parseArgs(process.argv);
+  const baseRef = typeof args['base-ref'] === 'string' ? args['base-ref'] : 'origin/main';
+  const headRef = typeof args['head-ref'] === 'string' ? args['head-ref'] : null;
+  const changedFilesArg = typeof args['changed-files'] === 'string' ? args['changed-files'] : null;
+
+  // Best-effort: keep origin/main fresh in CI/local, but don't hard-fail if remote isn't available.
+  try {
+    execFileSync('git', ['fetch', 'origin', 'main', '--quiet'], { stdio: 'ignore' });
+  } catch {
+    // ignore
+  }
+
+  /** @type {string[]} */
+  const changedFiles = changedFilesArg
+    ? changedFilesArg
+        .split(',')
+        .map((s) => normalizePath(s.trim()))
+        .filter(Boolean)
+    : listChangedFiles(baseRef);
+
+  const triggering = [...new Set(changedFiles.filter(matchesTrigger))].sort();
+
+  if (triggering.length === 0) {
+    console.log('OK: no SW cache bump required (no triggering files changed)');
+    process.exit(0);
+  }
+
+  let baseSw;
+  try {
+    baseSw = readSwFromRef(baseRef);
+  } catch (e) {
+    console.error(`FAIL: unable to read sw.js from ${baseRef}`);
+    console.error(String(e?.message || e));
+    process.exit(1);
+  }
+
+  let headSw;
+  try {
+    headSw = headRef ? readSwFromRef(headRef) : readSwFromWorktree();
+  } catch (e) {
+    console.error(headRef ? `FAIL: unable to read sw.js from ${headRef}` : 'FAIL: unable to read sw.js from working tree');
+    console.error(String(e?.message || e));
+    process.exit(1);
+  }
+
+  const baseVersion = extractCacheVersion(baseSw);
+  const headVersion = extractCacheVersion(headSw);
+
+  if (!baseVersion) {
+    console.error(`FAIL: could not find CACHE_VERSION in ${baseRef}:sw.js`);
+    process.exit(1);
+  }
+
+  if (!headVersion) {
+    console.error(headRef ? `FAIL: could not find CACHE_VERSION in ${headRef}:sw.js` : 'FAIL: could not find CACHE_VERSION in sw.js (working tree)');
+    process.exit(1);
+  }
+
+  if (baseVersion === headVersion) {
+    console.error('FAIL: SW cache bump required but CACHE_VERSION was not bumped');
+    console.error(`base (${baseRef}) CACHE_VERSION=${baseVersion}`);
+    console.error(`head (${headRef || 'worktree'}) CACHE_VERSION=${headVersion}`);
+    console.error('Triggering changed files:');
+    for (const f of triggering) console.error(`- ${f}`);
+    process.exit(1);
+  }
+
+  console.log('OK: SW cache bump satisfied');
+  console.log(`base (${baseRef}) CACHE_VERSION=${baseVersion}`);
+  console.log(`head (${headRef || 'worktree'}) CACHE_VERSION=${headVersion}`);
+  console.log('Triggering changed files:');
+  for (const f of triggering) console.log(`- ${f}`);
+}
+
+main();


### PR DESCRIPTION
Receipts (local, .reports is gitignored):\n- RUN_ID: 20260125-114619-6567\n- .reports/20260125-114619-6567/sw/\n- .reports/20260125-114619-6567/sec/\n\nNotes:\n- New work does NOT use .reports/_latest as input; it is only updated as a pointer after the run.\n