### PR TITLE
fix(design): restore CSS/JS delivery parity

### DIFF
--- a/EN/404.html
+++ b/EN/404.html
@@ -22,10 +22,10 @@
     <link rel="preload" as="image" href="/assets/img/logo-ea.webp" type="image/webp">
     
     <!-- Compiled CSS -->
-    <link rel="stylesheet" href="/assets/css/style.20260125-local.css">
-    <link rel="preload" href="/assets/css/style.20260125-local.css" as="style">
+    <link rel="stylesheet" href="/assets/css/style.css">
+    <link rel="preload" href="/assets/css/style.css" as="style">
     
-    <script src="/assets/js/site.min.20260125-local.js" defer></script>
+    <script src="/assets/js/site.min.js" defer></script>
     
     <!-- PWA Manifest -->
     <link rel="icon" type="image/png" sizes="32x32" href="/assets/img/favicon-32x32.png">
@@ -185,7 +185,7 @@
     </footer>
     
     <!-- Lazy Loader for Analytics & Dependencies -->
-    <script src="/assets/js/lazy-loader.min.20260125-local.js" defer></script>
+    <script src="/assets/js/lazy-loader.min.js" defer></script>
     <!-- Scroll to Top Button -->
     <button id="scroll-to-top" class="scroll-to-top-btn" type="button" title="Back to top" aria-label="Back to top" aria-describedby="scroll-to-top-tooltip">
         <svg class="scroll-progress-ring" viewBox="0 0 47 47" width="47" height="47" aria-hidden="true" focusable="false">

--- a/EN/about.html
+++ b/EN/about.html
@@ -24,9 +24,9 @@
     <!-- Preload Critical LCP Image -->
     <link rel="preload" as="image" href="/assets/img/logo-ea.webp" type="image/webp" fetchpriority="high">
     
-    <link rel="stylesheet" href="/assets/css/style.20260125-local.css">
+    <link rel="stylesheet" href="/assets/css/style.css">
     
-    <script src="/assets/js/site.min.20260125-local.js" defer></script>
+    <script src="/assets/js/site.min.js" defer></script>
     <!-- Theme CSS -->
     <noscript></noscript>
     
@@ -574,7 +574,7 @@
         </button>
     </div>
     
-    <script src="/assets/js/lazy-loader.min.20260125-local.js" defer></script>
+    <script src="/assets/js/lazy-loader.min.js" defer></script>
 </body>
 </html>
 

--- a/EN/contact.html
+++ b/EN/contact.html
@@ -24,9 +24,9 @@
     <!-- Preload Critical LCP Image -->
     <link rel="preload" as="image" href="/assets/img/logo-ea.webp" type="image/webp" fetchpriority="high">
     
-    <link rel="stylesheet" href="/assets/css/style.20260125-local.css">
+    <link rel="stylesheet" href="/assets/css/style.css">
     
-    <script src="/assets/js/site.min.20260125-local.js" defer></script>
+    <script src="/assets/js/site.min.js" defer></script>
     <!-- Theme CSS -->
     <noscript></noscript>
     
@@ -432,7 +432,7 @@
         </button>
     </div>
     
-    <script src="/assets/js/lazy-loader.min.20260125-local.js" defer></script>
+    <script src="/assets/js/lazy-loader.min.js" defer></script>
     <script src="/assets/js/contact-form.js" defer></script>
 
     <!-- Contact Success Modal -->

--- a/EN/deep-dive.html
+++ b/EN/deep-dive.html
@@ -26,9 +26,9 @@
     <!-- Preload Critical LCP Image -->
     <link rel="preload" as="image" href="/assets/img/logo-ea.webp" type="image/webp">
     
-    <link rel="stylesheet" href="/assets/css/style.20260125-local.css">
-    <link rel="preload" href="/assets/css/style.20260125-local.css" as="style">
-    <script src="/assets/js/site.min.20260125-local.js" defer></script>
+    <link rel="stylesheet" href="/assets/css/style.css">
+    <link rel="preload" href="/assets/css/style.css" as="style">
+    <script src="/assets/js/site.min.js" defer></script>
     <!-- Custom Theme CSS -->
     <!-- Analytics loaded via lazy-loader.js for better PageSpeed -->
 
@@ -581,7 +581,7 @@
         </button>
     </div>
     
-    <script src="/assets/js/lazy-loader.min.20260125-local.js" defer></script>
+    <script src="/assets/js/lazy-loader.min.js" defer></script>
 </body>
 </html>
 

--- a/EN/hobbies-games.html
+++ b/EN/hobbies-games.html
@@ -21,12 +21,12 @@
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet" crossorigin>
     
     <!-- Stylesheets -->
-    <link rel="stylesheet" href="/assets/css/style.20260125-local.css">
+    <link rel="stylesheet" href="/assets/css/style.css">
     <link rel="stylesheet" href="/theme.css?v=v20260119-5">
     <link rel="stylesheet" href="/assets/css/hobbies-games.css?v=20260120">
     
     <!-- Main Site Logic (Chat, Theme, etc.) -->
-    <script src="/assets/js/site.min.20260125-local.js" defer></script>
+    <script src="/assets/js/site.min.js" defer></script>
     <script type="module" src="/assets/js/arcade/arcade-core.js"></script>
     <script type="module" src="/assets/js/arcade/achievements-ui.js"></script>
     

--- a/EN/index.html
+++ b/EN/index.html
@@ -24,13 +24,13 @@
     <!-- Preload Critical LCP Image -->
     <link rel="preload" as="image" href="/assets/img/logo-ea.webp" type="image/webp" fetchpriority="high">
     
-    <link rel="stylesheet" href="/assets/css/style.20260125-local.css">
+    <link rel="stylesheet" href="/assets/css/style.css">
 
     <!-- Theme CSS (load as stylesheet to avoid CLS from late layout-affecting rules) -->
     <link rel="preload" as="style" href="/theme.css?v=v20260119-5">
     <link rel="stylesheet" href="/theme.css?v=v20260119-5">
 
-    <script src="/assets/js/site.min.20260125-local.js" defer></script>
+    <script src="/assets/js/site.min.js" defer></script>
     
     <!-- Analytics loaded via lazy-loader.js for better PageSpeed -->
 
@@ -501,7 +501,7 @@
         </button>
     </div>
     
-    <script src="/assets/js/lazy-loader.min.20260125-local.js" defer></script>
+    <script src="/assets/js/lazy-loader.min.js" defer></script>
 </body>
 </html>
 

--- a/EN/overview.html
+++ b/EN/overview.html
@@ -26,10 +26,10 @@
     <!-- Preload Critical LCP Image -->
     <link rel="preload" as="image" href="/assets/img/logo-ea.webp" type="image/webp">
     
-    <link rel="stylesheet" href="/assets/css/style.20260125-local.css">
-    <link rel="preload" href="/assets/css/style.20260125-local.css" as="style">
+    <link rel="stylesheet" href="/assets/css/style.css">
+    <link rel="preload" href="/assets/css/style.css" as="style">
     
-    <script src="/assets/js/site.min.20260125-local.js" defer></script>
+    <script src="/assets/js/site.min.js" defer></script>
     <!-- Theme CSS - loads reliably for all viewports -->
     <link rel="stylesheet" href="/theme.css?v=v20260119-5">
     
@@ -359,7 +359,7 @@
         </button>
     </div>
     
-    <script src="/assets/js/lazy-loader.min.20260125-local.js" defer></script>
+    <script src="/assets/js/lazy-loader.min.js" defer></script>
 </body>
 </html>
 

--- a/EN/privacy.html
+++ b/EN/privacy.html
@@ -27,10 +27,10 @@
     <!-- Preload Critical LCP Image -->
     <link rel="preload" as="image" href="/assets/img/logo-ea.webp" type="image/webp">
     
-    <link rel="stylesheet" href="/assets/css/style.20260125-local.css">
-    <link rel="preload" href="/assets/css/style.20260125-local.css" as="style">
+    <link rel="stylesheet" href="/assets/css/style.css">
+    <link rel="preload" href="/assets/css/style.css" as="style">
     
-    <script src="/assets/js/site.min.20260125-local.js" defer></script>
+    <script src="/assets/js/site.min.js" defer></script>
     <!-- Custom Theme CSS -->
     <!-- Analytics loaded via lazy-loader.js for better PageSpeed -->
 
@@ -390,7 +390,7 @@
         </button>
     </div>
     
-    <script src="/assets/js/lazy-loader.min.20260125-local.js" defer></script>
+    <script src="/assets/js/lazy-loader.min.js" defer></script>
 </body>
 </html>
 

--- a/ar/index.html
+++ b/ar/index.html
@@ -17,10 +17,10 @@
     <!-- Preload Critical LCP Image -->
     <link rel="preload" as="image" href="/assets/img/logo-ea.webp" type="image/webp">
     
-    <link rel="stylesheet" href="/assets/css/style.20260125-local.css">
-    <link rel="preload" href="/assets/css/style.20260125-local.css" as="style">
+    <link rel="stylesheet" href="/assets/css/style.css">
+    <link rel="preload" href="/assets/css/style.css" as="style">
     
-    <script src="/assets/js/site.min.20260125-local.js" defer></script>
+    <script src="/assets/js/site.min.js" defer></script>
     <!-- Custom Theme CSS (non-render-blocking) -->
     <link rel="stylesheet" href="/theme.css?v=v20260119-5" media="print" data-media="all">
     <noscript><link rel="stylesheet" href="/theme.css?v=v20260119-5"></noscript>
@@ -252,7 +252,7 @@
     <!-- GSAP + ScrollTrigger (moved to end of body for performance) -->
     
     <!-- Site JavaScript -->
-    <script src="/assets/js/site.min.20260125-local.js" defer></script>
+    <script src="/assets/js/site.min.js" defer></script>
     
     <!-- Lazy Loader for Analytics & Dependencies (moved to end of body) -->
     
@@ -295,7 +295,7 @@
         </button>
     </div>
     
-    <script src="/assets/js/lazy-loader.min.20260125-local.js" defer></script>
+    <script src="/assets/js/lazy-loader.min.js" defer></script>
         <!-- Scroll to Top Button -->
         <button id="scroll-to-top" class="scroll-to-top-btn" type="button" title="Back to top" aria-label="Back to top" aria-describedby="scroll-to-top-tooltip">
             <svg class="scroll-progress-ring" viewBox="0 0 47 47" width="47" height="47" aria-hidden="true" focusable="false">

--- a/es/index.html
+++ b/es/index.html
@@ -17,10 +17,10 @@
     <!-- Preload Critical LCP Image -->
     <link rel="preload" as="image" href="/assets/img/logo-ea.webp" type="image/webp">
     
-    <link rel="stylesheet" href="/assets/css/style.20260125-local.css">
-    <link rel="preload" href="/assets/css/style.20260125-local.css" as="style">
+    <link rel="stylesheet" href="/assets/css/style.css">
+    <link rel="preload" href="/assets/css/style.css" as="style">
     
-    <script src="/assets/js/site.min.20260125-local.js" defer></script>
+    <script src="/assets/js/site.min.js" defer></script>
     <!-- Custom Theme CSS (non-render-blocking) -->
     <link rel="stylesheet" href="/theme.css?v=v20260119-5" media="print" data-media="all">
     <noscript><link rel="stylesheet" href="/theme.css?v=v20260119-5"></noscript>
@@ -290,7 +290,7 @@
         </button>
     </div>
     
-    <script src="/assets/js/lazy-loader.min.20260125-local.js" defer></script>
+    <script src="/assets/js/lazy-loader.min.js" defer></script>
         <!-- Scroll to Top Button -->
         <button id="scroll-to-top" class="scroll-to-top-btn" type="button" title="Back to top" aria-label="Back to top" aria-describedby="scroll-to-top-tooltip">
             <svg class="scroll-progress-ring" viewBox="0 0 47 47" width="47" height="47" aria-hidden="true" focusable="false">

--- a/index.html
+++ b/index.html
@@ -25,13 +25,13 @@
     <!-- Preload Critical LCP Image -->
     <link rel="preload" as="image" href="/assets/img/logo-ea.webp" type="image/webp" fetchpriority="high">
     
-    <link rel="stylesheet" href="/assets/css/style.20260125-local.css">
+    <link rel="stylesheet" href="/assets/css/style.css">
 
     <!-- Theme CSS (load as stylesheet to avoid CLS from late layout-affecting rules) -->
     <link rel="preload" as="style" href="/theme.css?v=v20260119-5">
     <link rel="stylesheet" href="/theme.css?v=v20260119-5">
 
-    <script src="/assets/js/site.min.20260125-local.js" defer></script>
+    <script src="/assets/js/site.min.js" defer></script>
     
     <!-- Analytics loaded via lazy-loader.js for better PageSpeed -->
 
@@ -502,7 +502,7 @@
         </button>
     </div>
     
-    <script src="/assets/js/lazy-loader.min.20260125-local.js" defer></script>
+    <script src="/assets/js/lazy-loader.min.js" defer></script>
 </body>
 </html>
 

--- a/scripts/verify-deployment.ps1
+++ b/scripts/verify-deployment.ps1
@@ -7,9 +7,9 @@ Write-Host ""
 # Test assets on preview domain
 Write-Host "Testing preview domain (portfolio-site-t6q.pages.dev)..." -ForegroundColor Yellow
 $previewAssets = @(
-    "https://portfolio-site-t6q.pages.dev/assets/css/style.20260125-local.css",
-    "https://portfolio-site-t6q.pages.dev/assets/js/site.min.20260125-local.js",
-    "https://portfolio-site-t6q.pages.dev/assets/js/lazy-loader.min.20260125-local.js"
+    "https://portfolio-site-t6q.pages.dev/assets/css/style.css",
+    "https://portfolio-site-t6q.pages.dev/assets/js/site.min.js",
+    "https://portfolio-site-t6q.pages.dev/assets/js/lazy-loader.min.js"
 )
 
 foreach ($url in $previewAssets) {
@@ -30,9 +30,9 @@ foreach ($url in $previewAssets) {
 # Test assets on production domain
 Write-Host "Testing production domain (www.estivanayramia.com)..." -ForegroundColor Yellow
 $prodAssets = @(
-    "https://www.estivanayramia.com/assets/css/style.20260125-local.css",
-    "https://www.estivanayramia.com/assets/js/site.min.20260125-local.js",
-    "https://www.estivanayramia.com/assets/js/lazy-loader.min.20260125-local.js"
+    "https://www.estivanayramia.com/assets/css/style.css",
+    "https://www.estivanayramia.com/assets/js/site.min.js",
+    "https://www.estivanayramia.com/assets/js/lazy-loader.min.js"
 )
 
 foreach ($url in $prodAssets) {
@@ -52,38 +52,10 @@ foreach ($url in $prodAssets) {
     Write-Host ""
 }
 
-# Test non-stamped assets (should have short cache)
-Write-Host "Testing non-stamped assets (short cache)..." -ForegroundColor Yellow
-$shortCacheAssets = @(
-    "https://www.estivanayramia.com/assets/js/site.min.js",
-    "https://www.estivanayramia.com/assets/js/lazy-loader.min.js",
-    "https://www.estivanayramia.com/assets/css/style.css"
-)
-
-foreach ($url in $shortCacheAssets) {
-    try {
-        $response = Invoke-WebRequest -Uri $url -Method Head -ErrorAction Stop
-        $cacheControl = $response.Headers['Cache-Control']
-        Write-Host "✓ $url" -ForegroundColor Green
-        Write-Host "  Cache-Control: $cacheControl"
-        
-        if ($cacheControl -match "max-age=0") {
-            Write-Host "  ✓ Short cache confirmed" -ForegroundColor Green
-        } else {
-            Write-Host "  ✗ WARNING: Expected max-age=0" -ForegroundColor Red
-        }
-    } catch {
-        Write-Host "✗ $url - FAILED" -ForegroundColor Red
-        Write-Host "  Error: $($_.Exception.Message)"
-    }
-    Write-Host ""
-}
-
 Write-Host "=== VERIFICATION COMPLETE ===" -ForegroundColor Cyan
 Write-Host ""
 Write-Host "Expected results:" -ForegroundColor Yellow
-Write-Host "- Stamped assets: Content-Type should be text/css or application/javascript"
-Write-Host "- Stamped assets: Cache-Control should have max-age=31536000, immutable"
-Write-Host "- Non-stamped assets: Cache-Control should have max-age=0, must-revalidate"
+Write-Host "- Assets: Content-Type should be text/css or application/javascript"
+Write-Host "- Assets: Cache-Control should typically include max-age=0, must-revalidate (unless you intentionally use immutable fingerprinting)"
 Write-Host ""
 Write-Host "If all tests pass, the cache poison issue is fixed!" -ForegroundColor Green

--- a/sw.js
+++ b/sw.js
@@ -7,7 +7,7 @@
 //
 // Cache Version: Bump this whenever you deploy changes that affect cached files
 // ==========================================================================
-const CACHE_VERSION = 'v1769316949006';
+const CACHE_VERSION = 'v1769316949007';
 const CACHE_NAME = `portfolio-${CACHE_VERSION}`;
 const ASSETS_TO_CACHE = [
     '/',

--- a/tools/audit-html-sanity.cjs
+++ b/tools/audit-html-sanity.cjs
@@ -22,12 +22,9 @@ function getAllHtmlFiles(dir, fileList = []) {
 }
 
 const allHtmlFiles = getAllHtmlFiles(rootDir);
-const relevantFiles = allHtmlFiles.filter(f => {
-    const relPath = path.relative(rootDir, f).replace(/\\/g, '/');
-    return relPath.startsWith('EN/');
-});
+const relevantFiles = allHtmlFiles;
 
-console.log(`Scanning ${relevantFiles.length} HTML files in EN/ for sanity checks...`);
+console.log(`Scanning ${relevantFiles.length} HTML files for sanity checks...`);
 
 let failures = 0;
 
@@ -73,6 +70,13 @@ relevantFiles.forEach(file => {
          // This is common in text content, but in attributes?
          // Let's search specifically for things that look like errors.
     }
+
+    // Check 4: Guardrail against committing local-stamped asset URLs
+    // Example: /assets/css/style.20260125-local.css
+    if (content.match(/\/assets\/(?:css|js)\/[^"'\s>]+\.\d{8}-local\.(?:css|js)/i)) {
+        console.error(`[FAIL] ${relPath}: Found local-stamped asset URL (\\d{8}-local).`);
+        fileFailures++;
+    }
     
     if (fileFailures > 0) failures++;
 });
@@ -81,6 +85,6 @@ if (failures > 0) {
     console.log(`\nFound issues in ${failures} files.`);
     process.exit(1);
 } else {
-    console.log(`\nPASS: No malformed HTML patterns found in EN/**.`);
+    console.log(`\nPASS: No malformed HTML patterns found.`);
     process.exit(0);
 }


### PR DESCRIPTION
RUN_ID: 20260125-120803-1095

Receipts (local, .reports is gitignored):
- .reports/20260125-120803-1095/design-parity/diagnosis.txt
- .reports/20260125-120803-1095/design-parity/verdict.txt
- .reports/20260125-120803-1095/design-parity/fix.diff.txt
- .reports/20260125-120803-1095/design-parity/sw.bump.proof.txt
- .reports/20260125-120803-1095/design-parity/postfix.local.checks.txt

Summary:
- Removed all *.YYYYMMDD-local.* asset references from tracked HTML.
- Hardened stamping to prevent local-stamp rewrites of tracked HTML.
- Added audit to fail if local-stamp references exist.
- Bumped service worker CACHE_VERSION to force clients to refresh the shell.
